### PR TITLE
Fix Yarn resource builds (citizenfx/fivem#3892): spawn system Node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN apt-get update && apt upgrade -y && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN useradd -m -d /home/container container
 
 USER        container

--- a/start.sh
+++ b/start.sh
@@ -19,8 +19,24 @@ if [[ "${AUTO_UPDATE}" == "1" ]]; then
     tar -xvf ${DOWNLOAD_LINK##*/} > /dev/null 2>&1
     rm -rf ${DOWNLOAD_LINK##*/} run.sh > /dev/null 2>&1
     echo -e "${Text} ${BLUE}CitizenFX Resources updated successfully!${NC}"
-else 
+else
     echo -e "${Text} ${BLUE}Auto Update is disabled!${NC}"
+fi
+
+# Patch yarn_builder.js to use system Node instead of FXServer's bundled Node 22
+# Workaround for https://github.com/citizenfx/fivem/issues/3892
+YARN_BUILDER="/home/container/alpine/opt/cfx-server/citizen/system_resources/yarn/yarn_builder.js"
+if [ -f "$YARN_BUILDER" ]; then
+    if grep -q "execPath: '/usr/bin/node'" "$YARN_BUILDER"; then
+        echo -e "${Text} ${BLUE}yarn_builder.js already patched to use system Node.${NC}"
+    else
+        sed -i "s|stdio: 'pipe',|stdio: 'pipe',\n\t\t\t\texecPath: '/usr/bin/node',|" "$YARN_BUILDER"
+        if grep -q "execPath: '/usr/bin/node'" "$YARN_BUILDER"; then
+            echo -e "${Text} ${GREEN}Patched yarn_builder.js to use system Node (/usr/bin/node) instead of bundled Node.${NC}"
+        else
+            echo -e "${RED}[WARNING] Failed to patch yarn_builder.js - Yarn resource builds may fail.${NC}"
+        fi
+    fi
 fi
 
 echo -e "${Text} ${BLUE}Preparing environment variables...${NC}"

--- a/start.sh
+++ b/start.sh
@@ -23,20 +23,52 @@ else
     echo -e "${Text} ${BLUE}Auto Update is disabled!${NC}"
 fi
 
-# Patch yarn_builder.js to use system Node instead of FXServer's bundled Node 22
+# Patch yarn_builder.js to build Yarn resources with system Node instead of
+# FXServer's bundled Node 22.
+#
 # Workaround for https://github.com/citizenfx/fivem/issues/3892
+#
+# CitizenFX builds Yarn resources via child_process.fork(). fork() inherits the
+# parent's process.execArgv, and FXServer's patched parent node is launched with
+# loader flags (--library-path, --start-node, --fork-node22). Simply overriding
+# execPath kept those flags and made system node fail with
+# "bad option: --library-path". The verified fix (see issue #3892) is a plain
+# child_process.spawn('/usr/bin/node', [yarn_cli.js, 'install', ...]) which does
+# NOT pass execArgv, so no loader flags leak in.
+#
+# The rewrite below is content-anchored (not line-number based) and idempotent:
+# it normalises both a pristine fork() call and any previously-patched form to
+# the same known-good spawn() call, so it is safe across artifact updates.
 YARN_BUILDER="/home/container/alpine/opt/cfx-server/citizen/system_resources/yarn/yarn_builder.js"
 if [ -f "$YARN_BUILDER" ]; then
-    if grep -q "execPath: '/usr/bin/node'" "$YARN_BUILDER"; then
-        echo -e "${Text} ${BLUE}yarn_builder.js already patched to use system Node.${NC}"
-    else
-        sed -i "s|stdio: 'pipe',|stdio: 'pipe',\n\t\t\t\texecPath: '/usr/bin/node',|" "$YARN_BUILDER"
-        if grep -q "execPath: '/usr/bin/node'" "$YARN_BUILDER"; then
-            echo -e "${Text} ${GREEN}Patched yarn_builder.js to use system Node (/usr/bin/node) instead of bundled Node.${NC}"
-        else
-            echo -e "${RED}[WARNING] Failed to patch yarn_builder.js - Yarn resource builds may fail.${NC}"
-        fi
-    fi
+    PATCH_RESULT=$(/usr/bin/node -e '
+        const fs = require("fs");
+        const f = process.argv[1];
+        const src = fs.readFileSync(f, "utf8");
+        const re = /const proc = child_process\.(?:fork|spawn)\([\s\S]*?\}\s*\)\s*;/;
+        if (!re.test(src)) { process.stdout.write("ANCHOR_NOT_FOUND"); process.exit(0); }
+        const repl =
+            "const proc = child_process.spawn(\n" +
+            "\t\t\t\t\x27/usr/bin/node\x27,\n" +
+            "\t\t\t\t[require.resolve(\x27./yarn_cli.js\x27),\n" +
+            "\t\t\t\t\x27install\x27, \x27--ignore-scripts\x27, \x27--cache-folder\x27, path.join(initCwd, \x27cache\x27, \x27yarn-cache\x27), \x27--mutex\x27, \x27file:\x27 + path.join(initCwd, \x27cache\x27, \x27yarn-mutex\x27)],\n" +
+            "\t\t\t\t{\n" +
+            "\t\t\t\t\tcwd: path.resolve(GetResourcePath(resourceName)),\n" +
+            "\t\t\t\t\tstdio: \x27pipe\x27,\n" +
+            "\t\t\t\t});";
+        const out = src.replace(re, repl);
+        if (out === src) { process.stdout.write("ALREADY_OK"); process.exit(0); }
+        fs.writeFileSync(f, out);
+        process.stdout.write("PATCHED");
+    ' "$YARN_BUILDER" 2>/dev/null)
+    case "$PATCH_RESULT" in
+        PATCHED)
+            echo -e "${Text} ${GREEN}Patched yarn_builder.js to build resources with system Node via spawn().${NC}" ;;
+        ALREADY_OK)
+            echo -e "${Text} ${BLUE}yarn_builder.js already uses the system Node spawn() build.${NC}" ;;
+        *)
+            echo -e "${RED}[WARNING] Could not locate the yarn_builder.js spawn call (got: ${PATCH_RESULT:-empty}) - Yarn resource builds may fail.${NC}" ;;
+    esac
 fi
 
 echo -e "${Text} ${BLUE}Preparing environment variables...${NC}"


### PR DESCRIPTION
## Problem
`spawn /usr/bin/node ENOENT` (no system node) and, after the prior partial patch, `[yarn] /usr/bin/node: bad option: --library-path`.

The old patch only appended `execPath:'/usr/bin/node'` to the existing `child_process.fork()`. `fork()` still inherits `process.execArgv` from FXServer's patched parent node (`--library-path`, `--start-node`, `--fork-node22`), which system node rejects.

## Fix
Rewrite the call to `child_process.spawn('/usr/bin/node', [yarn_cli.js,'install',...])` (verified solution from citizenfx/fivem#3892). plain spawn does not pass `execArgv`, so no loader flags leak.

Patch is content-anchored (regex, not line numbers) and idempotent — normalises both a pristine `fork()` and any previously-patched form, safe across artifact updates.

## Verification
Built, pushed, and run on a live production FiveM server: yarn builds complete (`Done in Xs`), all resources start, no `ENOENT` / `--library-path` / `uv_close` errors. `:latest` promoted to the verified digest.